### PR TITLE
fix(testing): Allow package to be used successfully in tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,40 +1,69 @@
 'use strict';
 
 /**
- * If this bot is in dry run it executes no side effects
+ * If the code calling this module is in dry run mode, it causes no side effects
  */
+
+/** Global variable tracking the value of `process.env.DRY_RUN` */
 let dryRun;
 
 /**
- * Returns whether the DRY_RUN flag was set in the environment
+ * Tracks whether `setDryRun` has been used to manually override the value of
+ * `dryRun`
+ */
+let manualOverride = false;
+
+/**
+ * Resets `dryRun` to the value of `process.env.DRY_RUN`.
+ */
+function resetDryRun() {
+  dryRun = String(process.env.DRY_RUN || '');
+  manualOverride = false;
+}
+
+/**
+ * Returns whether the `DRY_RUN` flag is set in the environment, to anything
+ * other than `false`, `0` or `no`.
  *
- * If true, the application should execute "pure" (i.e. without any)
- * side effects. This is the opposite of {@link shouldPerform}. Use
- * {@link setDryRun} to manually set the value.
+ * If true, the code calling this should execute in a "pure" mode (i.e. without
+ * any side effects). This is the opposite of {@link shouldPerform}. Use
+ * {@link setDryRun} to manually override the value (or lack thereof) in the
+ * environment.
  *
  * @returns {bool}
  */
 function isDryRun() {
+  // When used in tests, this module is initialized before any tests run. That
+  // means that if the tests set `process.env.DRY_RUN`, its new value won't get
+  // picked up unless we go and grab it here. That said, always grabbing it here
+  // breaks `setDryRun`, so if that's been called (and `resetDryRun` hasn't been
+  // called afterwards), then let that value take precedence.
+  if (!manualOverride) {
+    resetDryRun();
+  }
+
   return (
     Boolean(dryRun) && dryRun !== 'false' && dryRun !== '0' && dryRun !== 'no'
   );
 }
 
 /**
- * Overrides the DRY_RUN value set in the environment
+ * Overrides the `DRY_RUN` value set in the environment
  *
- * @param {bool} active Whether to turn DRY_RUN on or off
+ * @param {bool} active Whether to turn `DRY_RUN` on or off
  */
 function setDryRun(active) {
   dryRun = String(active == null ? true : active);
+  manualOverride = true;
 }
 
 /**
- * Returns whether the DRY_RUN flag was absent in the environment
+ * Returns whether the `DRY_RUN` flag is absent in the environment, or set to
+ * `false`, `0` or `no`.
  *
- * If true, the application may execute side effects. This is the
- * opposite of {@link isDryRun}. Use {@link setDryRun} to manually
- * set the value.
+ * If true, the code calling this may cause side effects. This is the opposite
+ * of {@link isDryRun}. Use {@link setDryRun} to manually override the value (or
+ * lack thereof) in the environment.
  *
  * @returns {bool}
  */
@@ -42,14 +71,7 @@ function shouldPerform() {
   return !isDryRun();
 }
 
-/**
- * Resets the DRY_RUN flag to the environment value
- */
-function resetDryRun() {
-  dryRun = String(process.env.DRY_RUN || '');
-}
-
-// Initialize the DRY_RUN value
+// Initialize the `DRY_RUN` value
 resetDryRun();
 
 module.exports = {


### PR DESCRIPTION
Right now, absent any action on the user's part, the value of the global variable `dryRun` is set just once, [when this module is initialized](https://github.com/getsentry/node-dryrun/blob/07eb5a7f8afda84d01e0c1f681a726817532d2e2/lib/index.js#L53).

This is fine for normal use, because normally the value of `process.env.DRY_RUN` won't change during the lifetime of whatever script or app is using this package. However, if you use this package, and try to simulate dry run mode in a test, things don't work nearly as well, because the value of `dryRun` gets set _before_ your test has a chance to set the value of the environment variable.

The naive solution is to just always pull the value out of the environment, every time `isDryRun()` is called. While that does solve the above-mentioned problem, it cause another, namely that it breaks the ability to use `setDryRun()` to override the value of the env variable: you can change the value, but every time you try to see what the value is, you undo that effect. (h/t Heisenberg)

To avoid that second problem, this PR adds a second global variable, `manualOverride`, which tracks whether `setDryRun()` has been called (without an intervening call to `resetDryRun()`). If `dryRun` is in manual override mode, then calling `isDryRun()` leaves the value of `dryRun` alone.

Finally, I clarified a few of the functions' docstrings.